### PR TITLE
perf: reduce initial homepage overhead on mobile

### DIFF
--- a/src/components/IntroAudio.astro
+++ b/src/components/IntroAudio.astro
@@ -93,7 +93,7 @@ const { src, label = "INTRO.MP3", duration = 30 } = Astro.props;
   <span class="intro-label" aria-label={`Track: ${label}`}>{label}</span>
 
   <!-- Elemento audio nativo (oculto) -->
-  <audio id="intro-audio-el" preload="metadata" aria-hidden="true">
+  <audio id="intro-audio-el" preload="none" aria-hidden="true">
     <source src={src} type="audio/mpeg" />
     Tu navegador no soporta el elemento audio.
   </audio>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -67,18 +67,9 @@ const structuredData = {
       cssVariable="--font-wotfard"
       preload={[{ subset: "latin", weight: 400, style: "normal" }]}
     />
-    <Font
-      cssVariable="--font-sriracha"
-      preload={[{ subset: "latin", weight: 400, style: "normal" }]}
-    />
-    <Font
-      cssVariable="--font-cartograph"
-      preload={[{ subset: "latin", weight: 400, style: "normal" }]}
-    />
-    <Font
-      cssVariable="--font-cascadia-code"
-      preload={[{ subset: "latin", weight: 400, style: "normal" }]}
-    />
+    <Font cssVariable="--font-sriracha" />
+    <Font cssVariable="--font-cartograph" />
+    <Font cssVariable="--font-cascadia-code" />
 
     <!-- General Meta Tags -->
     <title>{title}</title>
@@ -296,6 +287,12 @@ const structuredData = {
     opacity: 1;
   }
 
+  @media (pointer: coarse) {
+    .site-cursor-glow {
+      display: none;
+    }
+  }
+
   .site-grain {
     position: absolute;
     inset: 0;
@@ -316,6 +313,9 @@ const structuredData = {
     if (cursorCleanup) cursorCleanup.abort();
     cursorCleanup = new AbortController();
     const { signal } = cursorCleanup;
+
+    const prefersFinePointer = window.matchMedia("(pointer: fine)").matches;
+    if (!prefersFinePointer) return;
 
     const cursorGlow = document.querySelector<HTMLElement>(".site-cursor-glow");
     let ticking = false;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -203,6 +203,13 @@ const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
       background-position: 100% center;
     }
   }
+
+  @media (prefers-reduced-motion: reduce), (max-width: 640px) {
+    .hero-title {
+      animation: none;
+      background-position: 50% center;
+    }
+  }
 </style>
 
 <script>
@@ -214,12 +221,14 @@ const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
     }
 
     // ── Card glow follow cursor ──
-    document.querySelectorAll<HTMLElement>(".card-glow").forEach(card => {
-      card.addEventListener("mousemove", (e: MouseEvent) => {
-        const rect = card.getBoundingClientRect();
-        card.style.setProperty("--mouse-x", `${e.clientX - rect.left}px`);
-        card.style.setProperty("--mouse-y", `${e.clientY - rect.top}px`);
+    if (window.matchMedia("(pointer: fine)").matches) {
+      document.querySelectorAll<HTMLElement>(".card-glow").forEach(card => {
+        card.addEventListener("mousemove", (e: MouseEvent) => {
+          const rect = card.getBoundingClientRect();
+          card.style.setProperty("--mouse-x", `${e.clientX - rect.left}px`);
+          card.style.setProperty("--mouse-y", `${e.clientY - rect.top}px`);
+        });
       });
-    });
+    }
   });
 </script>


### PR DESCRIPTION
## Summary
- stop preloading non-critical fonts to reduce initial network pressure
- defer intro audio loading by switching to preload=none
- skip cursor/card hover pointer logic on coarse pointers
- disable hero shimmer on small screens and reduced-motion

## Validation
- pnpm format
- pnpm lint
- pnpm build