### PR TITLE
ci: purge Cloudflare host cache after main Pages deploy

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+[mcp_servers.astro-docs]
+command = "npx"
+args = ["-y", "mcp-remote", "https://mcp.docs.astro.build/mcp"]

--- a/.github/workflows/cloudflare-purge-after-pages-deploy.yml
+++ b/.github/workflows/cloudflare-purge-after-pages-deploy.yml
@@ -1,0 +1,21 @@
+name: Purge Cloudflare Cache After Pages Deploy
+
+on:
+  check_run:
+    types: [completed]
+
+jobs:
+  purge-cache:
+    name: Purge Cloudflare Host Cache
+    if: >
+      github.event.check_run.name == 'Cloudflare Pages' &&
+      github.event.check_run.conclusion == 'success' &&
+      github.event.check_run.check_suite.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Purge host cache
+        run: |
+          curl -sS --fail -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_PURGE_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data '{"hosts":["www.vlucaswang.com"]}'


### PR DESCRIPTION
## Summary
- add a workflow triggered by completed check runs
- only run when the check run is Cloudflare Pages, successful, and for the main branch
- purge Cloudflare cache by host using existing repo secrets:
  - CLOUDFLARE_PURGE_API_TOKEN
  - CLOUDFLARE_ZONE_ID

## Purge mode
- host purge for www.vlucaswang.com